### PR TITLE
base and dev image definitions

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,12 @@
+# docker build -t ottwatch-dev .
+
+# docker run -t -i -p 80:80 ottwatch-dev
+# docker run -t -i ottwatch-dev
+
+FROM ubuntu:latest
+
+RUN apt-get update && \
+ apt-get -y install rails
+
+RUN gem install rails
+

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,12 @@
+# docker build -t ottwatch-dev .
+
+# docker run -t -i -p 80:80 ottwatch-dev
+# docker run -t -i ottwatch-dev
+
+FROM ubuntu:latest
+
+RUN apt-get update && \
+ apt-get -y install rails
+
+RUN gem install rails
+

--- a/docker/build-base.sh
+++ b/docker/build-base.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t ottwatch-base - < Dockerfile.base
+

--- a/docker/build-dev.sh
+++ b/docker/build-dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t ottwatch-dev - < Dockerfile.dev
+


### PR DESCRIPTION
Ottwatch will be based on Ubuntu linux.

The `base` image will be built to include OS and library dependencies. 

The `dev` image will be added on top to make it easier to run Ottwatch locally w/o depending on local state on your own workstation.