### PR TITLE
refactor docker builds

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -3,10 +3,10 @@
 # docker run -t -i -p 80:80 ottwatch-dev
 # docker run -t -i ottwatch-dev
 
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 RUN apt-get update && \
- apt-get -y install rails
+ apt-get -y install rails ruby-dev
 
 RUN gem install rails
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -3,10 +3,5 @@
 # docker run -t -i -p 80:80 ottwatch-dev
 # docker run -t -i ottwatch-dev
 
-FROM ubuntu:latest
-
-RUN apt-get update && \
- apt-get -y install rails
-
-RUN gem install rails
+FROM ottwatch-base
 

--- a/docker/build-base.sh
+++ b/docker/build-base.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+cd `dirname $0`
+
 docker build -t ottwatch-base - < Dockerfile.base
 

--- a/docker/build-dev.sh
+++ b/docker/build-dev.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+cd `dirname $0`
+
 docker build -t ottwatch-dev - < Dockerfile.dev
 

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+cd `dirname $0`
+
 docker run -i -t ottwatch-dev
 


### PR DESCRIPTION
Minor changes

- use a stable tag for Ubuntu to speed up container build times
- base `dev` version properly on `base`
- add SH files to remember docker CLI commands