### PR TITLE
mount app/code to /app in dev container

### DIFF
--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 cd `dirname $0`
+cd ..
 
-docker run -i -t ottwatch-dev
+docker run \
+  -v `pwd`:/app \
+  -i -t ottwatch-dev
 


### PR DESCRIPTION
By mounting the main repository directory in the `dev` container at runtime, we can code/edit/etc the contents of `/app` in the container and have that reflected in our main environment, for `git` purposes.

The intent is for `devs` to only "run" OttWatch in the container, including tests/etc, w/o having to worry about mutating their local environment.

But how can we submit code changes/git from a container w/o authentication? The answer: don't. Do that from your docker host/local environment.