### PR TITLE
add mysql dependencies

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,8 +6,8 @@
 FROM ubuntu:20.04
 
 RUN apt-get update
-RUN apt-get -y install rails ruby-dev
-RUN apt-get -y install build-essential npm curl
+RUN apt-get -y install rails ruby-dev mysql-server mysql-client vim curl
+RUN apt-get -y install build-essential npm
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -3,8 +3,10 @@
 cd `dirname $0`
 cd ..
 
+docker container rm ottwatch-dev 2>/dev/null
+
 docker run \
-  -v `pwd`:/app \
+  -v `pwd`:/ottwatch \
   -i -t \
   --name ottwatch-dev \
   ottwatch-dev


### PR DESCRIPTION
Quickies:

- add `mysql` to the container so we have a database to work with under Rails
- mount the repository under `/ottwatch` so the eventual Rails app can be in `/ottwatch/app`