### PR TITLE
export port 3000 on container to host port 33000

### DIFF
--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -7,6 +7,7 @@ docker container rm ottwatch-dev 2>/dev/null
 
 docker run \
   -v `pwd`:/ottwatch \
+  -p 33000:3000 \
   -i -t \
   --name ottwatch-dev \
   ottwatch-dev


### PR DESCRIPTION
When running the dev container, export port 3000 (the Rails server) on localhost port 33000 so we can hit "http://localhost:33000" to access the rails server running within the container.