### PR TITLE
bind to all interfaces not just localhost

### DIFF
--- a/app/config/puma.rb
+++ b/app/config/puma.rb
@@ -15,7 +15,8 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+# port ENV.fetch("PORT") { 3000 }
+bind 'tcp://0.0.0.0:3000'
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
By default puma is configured to bind to port 3000 on the localhost interface only; however that prevents the docker port forwarding from working, as the connection is routed to the RFC private network, within the container. 

Update to have puma bind and listen on all interfaces, so we can access the rails server from outside the container.