### PR TITLE
DevApp table and model

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -31,6 +31,9 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry'
+  gem 'pry-rails'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     erubi (1.10.0)
@@ -107,6 +108,14 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (5.2.1)
       nio4r (~> 2.0)
@@ -210,6 +219,9 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   mysql2 (~> 0.5)
+  pry
+  pry-byebug
+  pry-rails
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)

--- a/app/app/models/dev_app.rb
+++ b/app/app/models/dev_app.rb
@@ -1,0 +1,2 @@
+class DevApp < ApplicationRecord
+end

--- a/app/db/migrate/20210210021730_create_dev_apps.rb
+++ b/app/db/migrate/20210210021730_create_dev_apps.rb
@@ -1,0 +1,12 @@
+class CreateDevApps < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dev_apps do |t|
+      t.string :app_id, :limit => 32
+      t.string :dev_id, :limit => 32
+      t.string :app_type, :limit => 32
+      t.text :description
+      t.date :received_on
+      t.timestamps
+    end
+  end
+end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,6 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2021_02_10_021730) do
+
+  create_table "dev_apps", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "app_id", limit: 32
+    t.string "dev_id", limit: 32
+    t.string "app_type", limit: 32
+    t.text "description"
+    t.date "received_on"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end

--- a/app/test/fixtures/dev_apps.yml
+++ b/app/test/fixtures/dev_apps.yml
@@ -1,0 +1,14 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+duplex:
+  app_id: _duplex
+  dev_id: D1
+  app_type: Zoning
+  description: Owner wants R2 so they can build a duplex but Ottawa is stupid and still has R1 zoning
+  received_on: 2020-01-01
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>

--- a/app/test/models/dev_app_test.rb
+++ b/app/test/models/dev_app_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DevAppTest < ActiveSupport::TestCase
+  test "fixtures exist" do
+    assert_equal 1, DevApp.all.count
+  end
+end


### PR DESCRIPTION
A database table and model to represent Development Applications. Basing this on the previous OttWatch table: 

```
mysql> desc devapp;
+--------------+---------------+------+-----+---------+----------------+
| Field        | Type          | Null | Key | Default | Extra          |
+--------------+---------------+------+-----+---------+----------------+
| id           | mediumint(9)  | NO   | PRI | NULL    | auto_increment |
| appid        | varchar(10)   | YES  |     | NULL    |                |
| devid        | varchar(32)   | YES  |     | NULL    |                |
| ward         | varchar(100)  | YES  |     | NULL    |                |
| apptype      | varchar(100)  | YES  |     | NULL    |                |
| receiveddate | datetime      | YES  |     | NULL    |                |
| created      | datetime      | YES  |     | NULL    |                |
| updated      | datetime      | YES  |     | NULL    |                |
| address      | varchar(4096) | YES  |     | NULL    |                |
| description  | varchar(2048) | YES  |     | NULL    |                |
| coadesc      | varchar(4096) | YES  |     | NULL    |                |
+--------------+---------------+------+-----+---------+----------------+
```

Addresses is not included because I'm going to model that properly in a separate table. In the 1st version multiple addresses for a devapp were persisted as JSON arrays of lat/lon/address. That sucks. Gonna do better this time. 

Might add "COADESC" again... but I think that was a hack from before Ottawa had official SIRE entries for COA meetings.