### PR TITLE
add details to devapps

### DIFF
--- a/app/db/migrate/20210213144531_add_details_to_dev_apps.rb
+++ b/app/db/migrate/20210213144531_add_details_to_dev_apps.rb
@@ -1,0 +1,5 @@
+class AddDetailsToDevApps < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dev_apps, :details, :text
+  end
+end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_10_021730) do
+ActiveRecord::Schema.define(version: 2021_02_13_144531) do
 
   create_table "dev_apps", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "app_id", limit: 32
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2021_02_10_021730) do
     t.date "received_on"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "details"
   end
 
 end

--- a/bin/fix-thor.sh
+++ b/bin/fix-thor.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+dpkg -r --force-depends ruby-thor && \
+  gem install thor


### PR DESCRIPTION
`:details` column will hold the entire JSON details result from Ottawa's REST services. Some fields will be extracted to main columns, but I've decided this is a good field to `version` later on to detect deep changes in the devapp. 

In the original Ottwatch implementation I had separate tables for the supporting files, etc. I might just decide to leave everything in the JSON payload this time. No need for extra tables unless we want to enable searching for files/etc in an efficient manner. 