### PR TITLE
injest a dev apps

### DIFF
--- a/app/app/models/dev_app.rb
+++ b/app/app/models/dev_app.rb
@@ -1,2 +1,3 @@
 class DevApp < ApplicationRecord
+  serialize :details, JSON
 end

--- a/app/app/models/dev_app_scanner.rb
+++ b/app/app/models/dev_app_scanner.rb
@@ -25,7 +25,30 @@ class DevAppScanner
     # obtain full details on the application
     url = "https://devapps-restapi.ottawa.ca/devapps/#{appid}?authKey=#{authkey}"
     json = Net::HTTP.get(URI(url))
-    JSON.parse(json)
+  end
+
+  def injest_dev_app(devid)
+    details = JSON.parse(dev_app_details(devid))
+
+    dev_app = DevApp.find_by(dev_id: devid) || DevApp.new
+    dev_app.app_id = details['devAppId']
+    dev_app.dev_id = devid
+    dev_app.app_type = details['applicationType']['en']
+    dev_app.description = details['applicationBriefDesc']['en']
+    dev_app.received_on = details['applicationDateYMD']
+    dev_app.details = details
+
+    # TODO: state tracking of the status history; keep more than just today's snapshot/status.
+    #    "objectStatus"=>
+    # {"objectStatusTypeId"=>"__4BXROX",
+    #  "objectCurrentStatus"=>{"en"=>"Agreement Registered - Final Legal Clearance Given", "fr"=>"Entente Enregistr<C3><A9>e - Approbation Finale du Contentieux"},
+    #  "objectCurrentStatusDate"=>636409757630000000,
+    #  "objectCurrentStatusDateYMD"=>"2017-09-14"},
+
+    return dev_app unless dev_app.changed?
+
+    # TODO: write to FEED that a change (or new record) has been seen
+    dev_app.save!
   end
 
   private

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,7 +6,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-  apt-get -y install rails ruby-dev vim curl gnumeric && \
+  apt-get -y install rails ruby-dev vim curl gnumeric less && \
   apt-get -y install mysql-server mysql-client libmysqlclient-dev && \
   apt-get -y install build-essential npm && \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \


### PR DESCRIPTION
Given a dev_id, query the Ottawa REST server for details and persist the results locally in our own DB.

The raw details are retained as a long JSON field. We'll eventually extract more details from that payload.

Next up, run `injest...` in a loop against the set of all known DEV_IDs in order to have a local in-sync copy.