### PR TITLE
DevAppDetail model

### DIFF
--- a/app/app/models/dev_app.rb
+++ b/app/app/models/dev_app.rb
@@ -1,4 +1,8 @@
 class DevApp < ApplicationRecord
-  has_many :dev_app_detail
+  has_many :details, class_name: DevAppDetail.name
   serialize :details, JSON
+
+  def latest_details
+    details.last.details
+  end
 end

--- a/app/app/models/dev_app.rb
+++ b/app/app/models/dev_app.rb
@@ -1,3 +1,4 @@
 class DevApp < ApplicationRecord
+  has_many :dev_app_detail
   serialize :details, JSON
 end

--- a/app/app/models/dev_app_detail.rb
+++ b/app/app/models/dev_app_detail.rb
@@ -1,0 +1,4 @@
+class DevAppDetail < ApplicationRecord
+  has_one :dev_app
+  serialize :details, JSON
+end

--- a/app/app/models/dev_app_scanner.rb
+++ b/app/app/models/dev_app_scanner.rb
@@ -36,19 +36,15 @@ class DevAppScanner
     dev_app.app_type = details['applicationType']['en']
     dev_app.description = details['applicationBriefDesc']['en']
     dev_app.received_on = details['applicationDateYMD']
-    dev_app.details = details
-
-    # TODO: state tracking of the status history; keep more than just today's snapshot/status.
-    #    "objectStatus"=>
-    # {"objectStatusTypeId"=>"__4BXROX",
-    #  "objectCurrentStatus"=>{"en"=>"Agreement Registered - Final Legal Clearance Given", "fr"=>"Entente Enregistr<C3><A9>e - Approbation Finale du Contentieux"},
-    #  "objectCurrentStatusDate"=>636409757630000000,
-    #  "objectCurrentStatusDateYMD"=>"2017-09-14"},
-
-    return dev_app unless dev_app.changed?
-
-    # TODO: write to FEED that a change (or new record) has been seen
     dev_app.save!
+
+    if dev_details = dev_app.details.last
+      # TODO: handle updated details case
+    else
+      dev_details = dev_app.details.new
+      dev_details.details = details
+      dev_details.save!
+    end
   end
 
   private

--- a/app/db/migrate/20210214145824_create_dev_app_details.rb
+++ b/app/db/migrate/20210214145824_create_dev_app_details.rb
@@ -1,0 +1,10 @@
+class CreateDevAppDetails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dev_app_details do |t|
+      t.bigint :dev_app_id
+      t.text :details
+
+      t.timestamps
+    end
+  end
+end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_13_144531) do
+ActiveRecord::Schema.define(version: 2021_02_14_145824) do
+
+  create_table "dev_app_details", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "dev_app_id"
+    t.text "details"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "dev_apps", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "app_id", limit: 32

--- a/app/test/fixtures/dev_app_details.yml
+++ b/app/test/fixtures/dev_app_details.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  dev_app_id: 
+  details: MyText
+
+two:
+  dev_app_id: 
+  details: MyText

--- a/app/test/models/dev_app_detail_test.rb
+++ b/app/test/models/dev_app_detail_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DevAppDetailTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/app/test/models/dev_app_scanner_test.rb
+++ b/app/test/models/dev_app_scanner_test.rb
@@ -71,10 +71,12 @@ class DevAppScannerTest < ActiveSupport::TestCase
     end
   end
 
-  test '#injext_dev_app creates DevApp record when new devapp is injested' do 
+  test '#injest_dev_app creates DevApp & DevAppStatus records when new devapp is injested' do
     VCR.use_cassette(VCR_DEV_APP_DETAILS) do
-      assert_changes -> { DevApp.count } do 
-        @scanner.injest_dev_app(DEV_APP_ID)
+      assert_changes -> { DevAppDetail.count } do
+        assert_changes -> { DevApp.count } do
+          @scanner.injest_dev_app(DEV_APP_ID)
+        end
       end
 
       dev_app = DevApp.find_by(dev_id: DEV_APP_ID)
@@ -85,7 +87,7 @@ class DevAppScannerTest < ActiveSupport::TestCase
       assert_equal "Site Plan Control", dev_app[:app_type]
       assert_equal "New 16 unit building for affordable rental housing", dev_app[:description]
       assert_equal "2016-06-28".to_date, dev_app[:received_on]
-      assert_equal DEV_APP_DETAILS_EXPECTED_KEYS, dev_app.details.keys.sort
+      assert_equal DEV_APP_DETAILS_EXPECTED_KEYS, dev_app.latest_details.keys.sort
     end
   end
 


### PR DESCRIPTION
Keeping the full `details` payload in the main table was a bad idea. This column will change over time, as a development application moves through the process, and that's valuable state we want to retain.

I had thought of using `versioning` on the table, to track changes to the details column, but it's better to model this as a primary feature.