### PR TITLE
minitest-focus gem

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -55,6 +55,7 @@ group :test do
   gem 'webdrivers'
   gem 'vcr'
   gem 'webmock'
+  gem 'minitest-focus'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
-    i18n (1.8.8)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
@@ -105,6 +105,8 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
+    minitest-focus (1.2.1)
+      minitest (>= 4, < 6)
     msgpack (1.4.2)
     mysql2 (0.5.3)
     nio4r (2.5.5)
@@ -227,6 +229,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  minitest-focus
   mysql2 (~> 0.5)
   pry
   pry-byebug


### PR DESCRIPTION
This gem lets you add `focus` before any test and, when running the entire test via `rails test path/to/file_test.rb` it will only run the test you've requested for focus.