### PR TITLE
rake tast to scan and ingest all devapps

### DIFF
--- a/app/config/environments/development.rb
+++ b/app/config/environments/development.rb
@@ -73,4 +73,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Rails.logger = Logger.new(STDOUT)
+  config.logger = Logger.new(STDOUT)
 end

--- a/app/fixtures/vcr_cassettes/DevAppScannerTest_test__dev_app_details_raises_DevAppNotFound_if_the_devapp_does_not_exist.yml
+++ b/app/fixtures/vcr_cassettes/DevAppScannerTest_test__dev_app_details_raises_DevAppNotFound_if_the_devapp_does_not_exist.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://devapps-restapi.ottawa.ca/devapps/search?appStatus=all&appType=all&authKey=4r5T2egSmKm5&bounds=0,0,0,0&searchText=fake_kevino&ward=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - devapps-restapi.ottawa.ca
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 15 Feb 2021 01:44:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ott-Cache:
+      - '10'
+      Set-Cookie:
+      - NSC_QH_NzTP_ohjoy=ffffffffc3a0bc3845525d5f4f58455e445a4a42378b;expires=Mon,
+        15-Feb-2021 02:14:50 GMT;path=/;httponly
+      - incap_ses_529_2348304=3Y8KbVM8TQsGZFv4CmNXBxLSKWAAAAAAKVLWaIL9l6nybVr4SQnPYg==;
+        path=/; Domain=.ottawa.ca
+      - nlbi_2348304=CQdVL7v0HwVGEWQhl2uJLQAAAAAxXW+ESe3VRiHG7KZU+U4s; path=/; Domain=.ottawa.ca
+      - visid_incap_2348304=78mSFPY7SQqbFUE9sOfe7BLSKWAAAAAAQUIPAAAAAABH2l4DZg3bnCPAT8xYCl55;
+        expires=Mon, 14 Feb 2022 16:39:02 GMT; HttpOnly; path=/; Domain=.ottawa.ca
+      X-Cdn:
+      - Incapsula
+      X-Iinfo:
+      - 3-5004641-5004644 NNYY CT(0 0 0) RT(1613353490270 32) q(0 0 0 -1) r(1 1) U12
+    body:
+      encoding: ASCII-8BIT
+      string: '{"devApps":[],"totalDevApps":0,"index":0,"limit":0}'
+  recorded_at: Mon, 15 Feb 2021 01:44:50 GMT
+recorded_with: VCR 6.0.0

--- a/app/lib/tasks/ottwatch.rake
+++ b/app/lib/tasks/ottwatch.rake
@@ -1,0 +1,6 @@
+namespace :ottwatch do
+  desc "Scan all known devapps"
+  task scan_dev_apps: :environment do
+    DevAppScanner.new.scan_all
+  end
+end


### PR DESCRIPTION
- Implement a rake task that simply calls `#scan_all`
- improvements to logging, and handling error conditions seen in production.

The `not found` error was required because the XLS data of devapps includes an entry for `OLV2002-0020` which doesn't have details available in the REST api. 😢 