### PR TITLE
remove duplicate entries

### DIFF
--- a/app/app/models/dev_app_scanner.rb
+++ b/app/app/models/dev_app_scanner.rb
@@ -77,6 +77,7 @@ class DevAppScanner
     csv_data = devapp_csv_data(csv_path)
     csv_data = csv_data.map{ |row| row['Application Number'] }
     csv_data = csv_data.shuffle
+    csv_data = csv_data.uniq
     csv_data.each_with_index do |app_id,i|
       begin
         Rails.logger.info("ingesting #{i}/#{csv_data.count} #{app_id}")


### PR DESCRIPTION
The XLS (and then CSV) file accessed from Ottawa's open data portal contains many duplicates.

For example, `D07-16-16-0007` appears 36 times - but each row is exactly the same.

```bash
root@a68e6b8dde28:/ottwatch/app# grep D07-16-16-0007 /tmp/csv_file_43651411574.csv | wc -l
36
root@a68e6b8dde28:/ottwatch/app# grep D07-16-16-0007 /tmp/csv_file_43651411574.csv | sort -u
D07-16-16-0007,2016-06-10,"Plan of Subdivision",1500,"THOMAS ARGUE",Road,"Draft Approved",Inactive,"Jeffrey C Ostafichuk","application is for extension of an extisting draft plan of condominium","2016-09-23 15:54","Ward 5","WEST CARLETON-MARCH"
```

When scanning, `uniq` the array so we make `~1800` network calls, after de-duping, instead of `~4000` in the original file.