### PR TITLE
fix build dev container script

### DIFF
--- a/bin/build-dev.sh
+++ b/bin/build-dev.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 cd `dirname $0`
+cd ..
 
-docker build -t ottwatch-dev - < Dockerfile.dev
-
-docker container rm ottwatch-dev
+docker build -t ottwatch-dev -f Dockerfile.dev .
 


### PR DESCRIPTION
Use file reference instead of STDIN so relative file paths in dockerfile work.